### PR TITLE
Refactor App structure and enhance cleanup handling

### DIFF
--- a/pkg/ezapp/app.go
+++ b/pkg/ezapp/app.go
@@ -1,0 +1,9 @@
+package ezapp
+
+import "context"
+
+// App represents an application with runnables and cleanup functions.
+type App struct {
+	runnables []Runnable
+	cleanup   func(context.Context) error
+}

--- a/pkg/ezapp/appoptions.go
+++ b/pkg/ezapp/appoptions.go
@@ -1,0 +1,29 @@
+package ezapp
+
+import "context"
+
+// AppOption is a functional option for configuring an App.
+type AppOption func(*App)
+
+// WithRunnables adds one or more runnables to the App.
+func WithRunnables(runnables ...Runnable) AppOption {
+	return func(app *App) {
+		app.runnables = append(app.runnables, runnables...)
+	}
+}
+
+// WithCleanup sets the cleanup function for the App.
+func WithCleanup(cleanup func(context.Context) error) AppOption {
+	return func(app *App) {
+		app.cleanup = cleanup
+	}
+}
+
+// Construct creates a new App with the provided options.
+func Construct(options ...AppOption) App {
+	app := App{}
+	for _, option := range options {
+		option(&app)
+	}
+	return app
+}

--- a/pkg/ezapp/appoptions_test.go
+++ b/pkg/ezapp/appoptions_test.go
@@ -1,0 +1,115 @@
+package ezapp
+
+import (
+	"context"
+	"testing"
+)
+
+// TestConstruct tests the Construct function
+func TestConstruct(t *testing.T) {
+	// Create an App with no options
+	app := Construct()
+	if len(app.runnables) != 0 {
+		t.Errorf("Expected 0 runnables, got %d", len(app.runnables))
+	}
+	if app.cleanup != nil {
+		t.Errorf("Expected nil cleanup function, but it was not nil")
+	}
+}
+
+// TestWithRunnables tests the WithRunnables function
+func TestWithRunnables(t *testing.T) {
+	// Create a mock runnable
+	mockRun := mockRunnable{
+		runFunc: func(ctx context.Context) error {
+			return nil
+		},
+	}
+
+	// Create an App with one runnable
+	app := Construct(WithRunnables(mockRun))
+	if len(app.runnables) != 1 {
+		t.Errorf("Expected 1 runnable, got %d", len(app.runnables))
+	}
+
+	// Create an App with multiple runnables
+	app = Construct(WithRunnables(mockRun, mockRun))
+	if len(app.runnables) != 2 {
+		t.Errorf("Expected 2 runnables, got %d", len(app.runnables))
+	}
+
+	// Create an App with multiple WithRunnables calls
+	app = Construct(WithRunnables(mockRun), WithRunnables(mockRun))
+	if len(app.runnables) != 2 {
+		t.Errorf("Expected 2 runnables, got %d", len(app.runnables))
+	}
+}
+
+// TestWithCleanup tests the WithCleanup function
+func TestWithCleanup(t *testing.T) {
+	// Create a flag to track if cleanup was called
+	cleanupCalled := false
+
+	// Create a cleanup function
+	cleanup := func(ctx context.Context) error {
+		cleanupCalled = true
+		return nil
+	}
+
+	// Create an App with a cleanup function
+	app := Construct(WithCleanup(cleanup))
+	if app.cleanup == nil {
+		t.Errorf("Expected non-nil cleanup function")
+	}
+
+	// Call the cleanup function
+	err := app.cleanup(context.Background())
+	if err != nil {
+		t.Errorf("Expected no error from cleanup, got %v", err)
+	}
+	if !cleanupCalled {
+		t.Errorf("Expected cleanup function to be called")
+	}
+}
+
+// TestMultipleOptions tests using multiple options together
+func TestMultipleOptions(t *testing.T) {
+	// Create a mock runnable
+	mockRun := mockRunnable{
+		runFunc: func(ctx context.Context) error {
+			return nil
+		},
+	}
+
+	// Create a flag to track if cleanup was called
+	cleanupCalled := false
+
+	// Create a cleanup function
+	cleanup := func(ctx context.Context) error {
+		cleanupCalled = true
+		return nil
+	}
+
+	// Create an App with both runnables and cleanup
+	app := Construct(
+		WithRunnables(mockRun, mockRun),
+		WithCleanup(cleanup),
+	)
+
+	// Check that both options were applied
+	if len(app.runnables) != 2 {
+		t.Errorf("Expected 2 runnables, got %d", len(app.runnables))
+	}
+	if app.cleanup == nil {
+		t.Errorf("Expected non-nil cleanup function")
+	}
+
+	// Call the cleanup function
+	err := app.cleanup(context.Background())
+	if err != nil {
+		t.Errorf("Expected no error from cleanup, got %v", err)
+	}
+	if !cleanupCalled {
+		t.Errorf("Expected cleanup function to be called")
+	}
+}

--- a/pkg/ezapp/builder.go
+++ b/pkg/ezapp/builder.go
@@ -1,3 +1,3 @@
 package ezapp
 
-type Builder[CONF any] func(CONF) ([]Runnable, error)
+type Builder[CONF any] func(CONF) (App, error)

--- a/pkg/ezapp/run.go
+++ b/pkg/ezapp/run.go
@@ -7,40 +7,149 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
+	"strconv"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/Netflix/go-env"
 )
 
 var osExit = os.Exit
 
-// Run creates an application from the provided builder function and runs it.
-// It executes the builder to get runnables, then starts all runnables while listening for stop signals.
-func Run[CONF any](builder Builder[CONF]) {
-	var conf CONF
+// GetCleanupTimeout returns the timeout duration for the cleanup function.
+// It retrieves the timeout in seconds from the EZAPP_TERM_TIMEOUT environment variable.
+// If not found, it defaults to 15 seconds.
+func GetCleanupTimeout() time.Duration {
+	timeoutStr := os.Getenv("EZAPP_TERM_TIMEOUT")
+	if timeoutStr == "" {
+		return 15 * time.Second
+	}
 
+	timeoutSec, err := strconv.Atoi(timeoutStr)
+	if err != nil {
+		// If the value is not a valid integer, use the default
+		return 15 * time.Second
+	}
+
+	return time.Duration(timeoutSec) * time.Second
+}
+
+// validateAndLoadConfig validates that CONF is a struct and loads environment variables into it.
+func validateAndLoadConfig[CONF any](conf *CONF) error {
 	// Validate that CONF is a struct
-	if reflect.TypeOf(conf).Kind() != reflect.Struct {
-		fmt.Printf("App shutting down: Initialization error: %v\n", errors.New("CONF must be a struct"))
-		osExit(1)
-		return
+	if reflect.TypeOf(*conf).Kind() != reflect.Struct {
+		return errors.New("CONF must be a struct")
 	}
 
 	// Use go-env to populate CONF from environment variables
-	if _, err := env.UnmarshalFromEnviron(&conf); err != nil {
-		fmt.Printf("App shutting down: Initialization error: %v\n", fmt.Errorf("failed to parse environment variables into CONF: %w", err))
+	if _, err := env.UnmarshalFromEnviron(conf); err != nil {
+		return fmt.Errorf("failed to parse environment variables into CONF: %w", err)
+	}
+
+	return nil
+}
+
+// startRunnables starts all runnables in separate goroutines and returns channels for errors and completion.
+func startRunnables(ctx context.Context, runnables []Runnable) (chan error, chan struct{}, context.CancelFunc) {
+	// Create a cancellable context
+	runCtx, cancel := context.WithCancel(ctx)
+
+	// Create error channel to collect errors from runnables
+	errChan := make(chan error, len(runnables))
+
+	// Create a wait group to wait for all runnables to finish
+	var wg sync.WaitGroup
+
+	// Start all runnables
+	for _, runnable := range runnables {
+		wg.Add(1)
+		go func(r Runnable) {
+			defer wg.Done()
+			if err := r.Run(runCtx); err != nil {
+				select {
+				case errChan <- err:
+					// Error sent successfully
+				case <-runCtx.Done():
+					// Context already cancelled, no need to send error
+				}
+				cancel() // Cancel context on error
+			}
+		}(runnable)
+	}
+
+	// Create a channel to signal when all runnables are done
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	return errChan, done, cancel
+}
+
+// waitForShutdown waits for either a signal, an error, or all runnables to finish.
+func waitForShutdown(sigChan chan os.Signal, errChan chan error, done chan struct{}, cancel context.CancelFunc) (int, string) {
+	// Wait for either an error, SIGINT, SIGTERM, or all runnables to finish
+	var exitCode int
+	var shutdownReason string
+	select {
+	case sig := <-sigChan:
+		// Received SIGINT or SIGTERM, cancel context
+		shutdownReason = fmt.Sprintf("Received signal %s", sig.String())
+		cancel()
+		exitCode = 0 // Normal termination due to signal
+	case err := <-errChan:
+		// Received an error from a runnable
+		shutdownReason = fmt.Sprintf("Runnable error: %v", err)
+		// Context is already cancelled in the goroutine
+		exitCode = 1 // Error termination
+	case <-done:
+		// All runnables finished successfully
+		shutdownReason = "All runnables completed successfully"
+		exitCode = 0 // Success
+	}
+
+	return exitCode, shutdownReason
+}
+
+// runCleanup runs the cleanup function with a timeout.
+func runCleanup(cleanup func(context.Context) error) (int, error) {
+	fmt.Println("Running cleanup function")
+	// Create a context with timeout for the cleanup function
+	timeout := GetCleanupTimeout()
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	err := cleanup(cleanupCtx)
+	if err != nil {
+		return 1, err
+	}
+	return 0, nil
+}
+
+// Run creates an application from the provided builder function and runs it.
+// It executes the builder to get an App, then starts all runnables while listening for stop signals.
+func Run[CONF any](builder Builder[CONF]) {
+	var conf CONF
+
+	// Validate and load configuration
+	if err := validateAndLoadConfig(&conf); err != nil {
+		fmt.Printf("App shutting down: Initialization error: %v\n", err)
 		osExit(1)
 		return
 	}
 
-	// Call the builder function to get the list of runnables
-	runnables, err := builder(conf)
+	// Call the builder function to get the App
+	app, err := builder(conf)
 	if err != nil {
 		fmt.Printf("App shutting down: Initialization error: %v\n", err)
 		osExit(1)
 		return
 	}
+
+	// Get the runnables from the App
+	runnables := app.runnables
 
 	// Check if there are any runnables to run
 	if len(runnables) == 0 {
@@ -56,63 +165,34 @@ func Run[CONF any](builder Builder[CONF]) {
 	// Set up signal handling for SIGINT and SIGTERM
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(sigChan) // Stop signal handling when done
-
-	// Create error channel to collect errors from runnables
-	errChan := make(chan error, len(runnables))
-
-	// Create a wait group to wait for all runnables to finish
-	var wg sync.WaitGroup
 
 	// Start all runnables
-	for _, runnable := range runnables {
-		wg.Add(1)
-		go func(r Runnable) {
-			defer wg.Done()
-			if err := r.Run(ctx); err != nil {
-				select {
-				case errChan <- err:
-					// Error sent successfully
-				case <-ctx.Done():
-					// Context already cancelled, no need to send error
-				}
-				cancel() // Cancel context on error
-			}
-		}(runnable)
+	errChan, done, runnablesCancel := startRunnables(ctx, runnables)
+
+	// Wait for shutdown
+	exitCode, shutdownReason := waitForShutdown(sigChan, errChan, done, runnablesCancel)
+
+	fmt.Printf("App shutting down: %s\n", shutdownReason)
+
+	// If we're not already done, wait for all runnables to finish
+	if shutdownReason != "All runnables completed successfully" {
+		<-done
 	}
-
-	// Create a channel to signal when all runnables are done
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	// Wait for either an error, SIGINT, SIGTERM, or all runnables to finish
-	var exitCode int
-	select {
-	case sig := <-sigChan:
-		// Received SIGINT or SIGTERM, cancel context
-		fmt.Printf("App shutting down: Received signal %s\n", sig.String())
-		cancel()
-		exitCode = 0 // Normal termination due to signal
-	case err := <-errChan:
-		// Received an error from a runnable
-		fmt.Printf("App shutting down: Runnable error: %v\n", err)
-		// Context is already cancelled in the goroutine
-		exitCode = 1 // Error termination
-	case <-done:
-		// All runnables finished successfully
-		fmt.Println("App shutting down: All runnables completed successfully")
-		osExit(0) // Exit immediately with success code
-		return
-	}
-
-	// Wait for all runnables to finish
-	<-done
 
 	// Close the error channel
 	close(errChan)
+
+	// Call the cleanup function if it exists
+	if app.cleanup != nil {
+		cleanupExitCode, err := runCleanup(app.cleanup)
+		if err != nil {
+			fmt.Printf("Cleanup error: %v\n", err)
+			exitCode = cleanupExitCode
+		}
+	}
+	signal.Stop(sigChan) // Stop signal handling when done
+	close(sigChan)
+	runnablesCancel()
 
 	fmt.Println("App shutdown complete")
 	osExit(exitCode)


### PR DESCRIPTION
Introduce `App` abstraction with support for runnables and cleanup via new functional options (`WithRunnables`, `WithCleanup`). Refactor `Run` to handle `App` instances and improve cleanup logic, including configurable timeout and error reporting. Update tests to cover the new behavior.